### PR TITLE
Add support for oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ antigen bundle "MichaelAquilina/zsh-you-should-use"
 zgen load "MichaelAquilina/zsh-you-should-use"
 ```
 
+[oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+
+Copy this repository to `$ZSH/custom/plugins`, where `$ZSH` is the root directory of oh-my-zsh.  Then add this line to your `.zshrc`
+```
+plugins=(you-should-use $plugins)
+```
+
 Displaying Results
 ------------------
 

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -52,4 +52,5 @@ function _check_aliases() {
   fi
 }
 
+autoload -U add-zsh-hook
 add-zsh-hook preexec _check_aliases


### PR DESCRIPTION
Actually this is a fix for this error:
```
$OH_MY_ZSH_ROOT/custom/plugins/you-should-use/you-should-use.plugin.zsh:55: command not found: add-zsh-hook
```