### PR TITLE
Add copy+paste command to clone repo for oh-my-zsh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,14 @@ Zgen_
 oh-my-zsh_
 
 Copy this repository to ``$ZSH/custom/plugins``, where ``$ZSH`` is the
-root directory of oh-my-zsh. Then add this line to your ``.zshrc``
+root directory of oh-my-zsh:
+
+::
+
+    git clone git@github.com:MichaelAquilina/zsh-you-should-use.git $ZSH/custom/plugins/zsh-you-should-use
+
+
+Then add this line to your ``.zshrc``
 
 ::
 


### PR DESCRIPTION
A nice command for copy+paste when installing in oh-my-zsh to clone repo. This assumes that the $ZSH is available, and it should be as it is the default in oh-my-zsh.