### PR TITLE
Make hardcore mode more distinguished

### DIFF
--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -7,7 +7,7 @@ NONE='\e[0m'
 RED='\e[31m'
 YELLOW='\e[33m'
 DEFAULT='\e[39m'
-DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}Found existing %alias_type for \"%command\". You should use: \"%alias\"${NONE}${DEFAULT}"
+DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}Found existing %alias_type for \"%command\". You can use: \"%alias\"${NONE}${DEFAULT}"
 
 
 function ysu_message() {


### PR DESCRIPTION
This changes non-hardcore to mention you "can" use, to imply that it's optional, while hardcore mode will mention you *should*.
This comes from complaints I have heard around, where people mentioned YSU is harsh even not using hardcore.

If you don't like that change feel free to dismiss the PR of course.
This is intended as a suggestion. :)