### PR TITLE
Match full git aliases with any order of arguments

### DIFF
--- a/tests/test_git_aliases.zunit
+++ b/tests/test_git_aliases.zunit
@@ -56,5 +56,20 @@
 
    assert "$output" contains 'Found existing git alias for "status". You should use: "git st"'
    assert $state equals 0
+}
 
+@test 'git aliases match parameters' {
+   git config --global alias.recommit "commit --amend --reuse-message=HEAD"
+   run _check_git_aliases "git commit --amend --reuse-message=HEAD" "git commit --amend --reuse-message=HEAD"
+
+   assert "$output" contains 'Found existing git alias for "commit --amend --reuse-message=HEAD". You should use: "git recommit"'
+   assert $state equals 0
+}
+
+@test 'git aliases not triggered when parameters are different' {
+   git config --global alias.recommit "commit --amend --reuse-message=HEAD"
+   run _check_git_aliases "git commit" "git commit"
+
+   assert "$output" is_empty
+   assert $state equals 0
 }

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -60,13 +60,10 @@ function _check_ysu_hardcore() {
 function _check_git_aliases() {
   if [[ "$1" = "git "* ]]; then
       local found=false
-      local tokens
       local k
       local v
-      git config --get-regexp "^alias\..+$" | sort | while read entry; do
-        tokens=("${(@s/ /)entry}")
-        k="${tokens[1]#alias.}"
-        v="${tokens[2]}"
+      git config --get-regexp "^alias\..+$" | sort | while read k v; do
+        k="${k#alias.}"
 
         if [[ "$2" = "git $v" || "$2" = "git $v "* ]]; then
           ysu_message "git alias" "$v" "git $k"


### PR DESCRIPTION
This fixes git alias matching for aliases with parameters (#66).

I made two variants of this. In this one, the order of arguments is irellevant, as long as all arguments in the alias occur in the actual command. The other one in branch [git-alias-exact-match](/crater2150/zsh-you-should-use/tree/git-alias-exact-match) only matches if the command starts with the exact string from the arguments.

So in this variant, for `alias.recommit commit --amend --reuse-message=HEAD`:
```
git commit --amend --reuse-message=HEAD
git commit --amend --reuse-message=HEAD --some-further-param
git commit --reuse-message=HEAD --amend
git commit --reuse-message=HEAD --amend --some-further-param
git commit --prepended-param --reuse-message=HEAD --amend
```
will all match. The other variant would only match the first two. I think this variant works well, but may possibly have edge cases when there are parameters that could mean different things depending on position (e.g. branch names)