### PR TITLE
Make entry local to _check_global_aliases

### DIFF
--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -156,6 +156,7 @@ function _check_global_aliases() {
     local tokens
     local key
     local value
+    local entry
 
     # sudo will use another user's profile and so aliases would not apply
     if [[ "$typed" = "sudo "* ]]; then


### PR DESCRIPTION
Another one.

I think the source of the problem is that Zsh behaves like Bash `shopt -s lastpipe` by default, where the last command list in a pipeline is executed in the current environment:

```
echo ${var1=set} | read var2
echo ${var1-unset} ${var2-unset}
```

In Zsh, this prints `unset set`, but in Bash, this prints `unset unset`.