### PR TITLE
"disabling aliases" renamed to "disabling hints"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Advanced Features
 
 * `Hardcore Mode`_
 * `Check your Alias usage`_
-* `Permanently Disabling Aliases`_
+* `Disable Hints for specific Aliases`_
 * `Temporarily Disabling Messages`_
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -240,8 +240,8 @@ In the example below, history is limited to the last 200 entries when generating
     1: gs='git status'
 
 
-Ignoring Aliases
------------------------------
+Disable Hints for specific Aliases
+----------------------------------
 
 You can tell ``you-should-use`` to permanently ignore certain aliases by including them in the ``YSU_IGNORED_ALIASES`` variable (which is an array):
 

--- a/README.rst
+++ b/README.rst
@@ -240,10 +240,10 @@ In the example below, history is limited to the last 200 entries when generating
     1: gs='git status'
 
 
-Permanently Disabling Aliases
+Ignoring Aliases
 -----------------------------
 
-You can permanently disable aliases by including them in the ``YSU_IGNORED_ALIASES`` variable (which is an array):
+You can tell ``you-should-use`` to permanently ignore certain aliases by including them in the ``YSU_IGNORED_ALIASES`` variable (which is an array):
 
 ::
 


### PR DESCRIPTION
The phrasing of "disabling" aliases is quite confusing, at first I thought it would turn the aliases completely off, which it does not. I changed the wording to "ignore aliases" to make the feature more clear.

Great little tool btw, thanks a lot for it! 