### PR TITLE
Add symlink for easier installation

### DIFF
--- a/zsh-you-should-use.plugin.zsh
+++ b/zsh-you-should-use.plugin.zsh
@@ -1,0 +1,1 @@
+you-should-use.plugin.zsh


### PR DESCRIPTION
This PR adds a symlink to the plugin file so that it has the same name as the repo.

This could make installation easier for cases such as automated install scripts ([example](https://github.com/kaykayehnn/dotfiles/blob/981c935ae24043c10fa2584d9554d8f2f03f3d1d/tools/install.sh#L126-L139))

As it is currently, the repo name being different from the plugin file makes it a bit cumbersome to add it to oh-my-zsh's plugin array because it expects both the directory and plugin file to have the same name. My use case, which clones the plugin without renaming it, results in `[oh-my-zsh] plugin 'zsh-you-should-use' not found` because of this.

I'd be happy if you accepted this change as both the current suggested installation at `plugins/you-should-use` will keep working and installing as `plugins/zsh-you-should-use` will be supported as well