### PR TITLE
Fix path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Install ``zsh-you-should-use`` with Fig in just one click.
 
 oh-my-zsh_
 
-Clone this repository into ``$ZSH_CUSTOM/custom/plugins``:
+Clone this repository into ``$ZSH_CUSTOM/plugins``:
 
 .. code-block:: sh
 


### PR DESCRIPTION
`$ZSH_CUSTOM/custom/plugins` does not exist, but `$ZSH_CUSTOM/plugins` does.
And the suggest code to run just below actually points to `$ZSH_CUSTOM/plugins`.