### PR TITLE
New function: you-used (alias usage reminder)

### DIFF
--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -307,7 +307,7 @@ function ysu_message() {
     local command_arg="$2"
     local abbreviation_arg="$3"
     local DEFAULT_MESSAGE_FORMAT=""
-    
+
     # Escape arguments for safe output
     command_arg="${command_arg//\%/%%}"
     command_arg="${command_arg//\\/\\\\}"
@@ -330,7 +330,7 @@ You should use: ${PURPLE}\"$abbreviation_arg\"${NONE}"
             ;;
         "used alias")
             if zstyle -t ':you-should-use:*' you_used_alias_enabled; then
-                DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}You used the alias for ${PURPLE}\"$command_arg\"${YELLOW}, which is: ${PURPLE}\"$abbreviation_arg\"${NONE}"
+                DEFAULT_MESSAGE_FORMAT="${BOLD} ${PURPLE}\"$command_arg\"${YELLOW} -> ${PURPLE}\"$abbreviation_arg\"${NONE}"
             fi
             ;;
     esac

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-export YSU_VERSION='1.7.3'
+export YSU_VERSION='1.7.4'
 
 if ! type "tput" > /dev/null; then
     printf "WARNING: tput command not found on your PATH.\n"
@@ -88,7 +88,6 @@ function _flush_ysu_buffer() {
     _YSU_BUFFER=""
 }
 
-
 function ysu_message() {
     local alias_type_arg="${1}"
     local command_arg="${2}"
@@ -133,31 +132,6 @@ You should use: ${PURPLE}\"%alias\"${NONE}"
     _write_ysu_buffer "$MESSAGE\n"
 }
 
-
-function ysu_message_og() {
-    local DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}\
-Found existing %alias_type for ${PURPLE}\"%command\"${YELLOW}. \
-You should use: ${PURPLE}\"%alias\"${NONE}"
-
-    local alias_type_arg="${1}"
-    local command_arg="${2}"
-    local alias_arg="${3}"
-
-    # Escape arguments which will be interpreted by printf incorrectly
-    # unfortunately there does not seem to be a nice way to put this into
-    # a function because returning the values requires to be done by printf/echo!!
-    command_arg="${command_arg//\%/%%}"
-    command_arg="${command_arg//\\/\\\\}"
-
-    local MESSAGE="${YSU_MESSAGE_FORMAT:-"$DEFAULT_MESSAGE_FORMAT"}"
-    MESSAGE="${MESSAGE//\%alias_type/$alias_type_arg}"
-    MESSAGE="${MESSAGE//\%command/$command_arg}"
-    MESSAGE="${MESSAGE//\%alias/$alias_arg}"
-
-    _write_ysu_buffer "$MESSAGE\n"
-}
-
-
 # Prevent command from running if hardcore mode enabled
 function _check_ysu_hardcore() {
     if [[ "$YSU_HARDCORE" = 1 ]]; then
@@ -165,7 +139,6 @@ function _check_ysu_hardcore() {
         kill -s INT $$
     fi
 }
-
 
 function _check_git_aliases() {
     local typed="$1"
@@ -199,7 +172,6 @@ function _check_git_aliases() {
         fi
     fi
 }
-
 
 function _check_global_aliases() {
     local typed="$1"
@@ -244,9 +216,7 @@ function _check_global_aliases() {
 function _check_aliases() {
     local typed="$1"
     local expanded="$2"
-    local first_word="${typed%% *}"  # Extracts the first word from the typed command
-    local found_aliases
-    found_aliases=()
+    local found_aliases=()
     local best_match=""
     local best_match_value=""
     local key

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -375,8 +375,8 @@ function enable_you_should_use() {
 }
 
 zstyle ':you-should-use:*' you_should_use_alias_enabled true
-zstyle ':you-should-use:*' you_used_alias_enabled true
-zstyle ':you-should-use:*' you_should_use_abbreviation_enabled true
+zstyle ':you-should-use:*' you_used_alias_enabled false
+zstyle ':you-should-use:*' you_should_use_abbreviation_enabled false
 
 autoload -Uz add-zsh-hook
 enable_you_should_use

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -143,6 +143,41 @@ function _flush_ysu_buffer() {
     _YSU_BUFFER=""
 }
 
+function ysu_message() {
+    local message_type="$1"
+    local command_arg="$2"
+    local abbreviation_arg="$3"
+    local DEFAULT_MESSAGE_FORMAT=""
+
+    # Escape arguments for safe output
+    command_arg="${command_arg//\%/%%}"
+    command_arg="${command_arg//\\/\\\\}"
+    abbreviation_arg="${abbreviation_arg//\%/%%}"
+    abbreviation_arg="${abbreviation_arg//\\/\\\\}"
+
+    # Determine message format based on message type and whether it's enabled
+    case "$message_type" in
+        "abbreviation")
+            if zstyle -t ':you-should-use:*' you_should_use_abbreviation_enabled; then
+                DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}Found existing abbreviation for ${PURPLE}\"$command_arg\"${YELLOW}. \
+You should use: ${PURPLE}\"$abbreviation_arg\"${NONE}"
+            fi
+            ;;
+        "alias")
+            if zstyle -t ':you-should-use:*' you_should_use_alias_enabled; then
+                DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}Found existing alias for ${PURPLE}\"$command_arg\"${YELLOW}. \
+You should use: ${PURPLE}\"$abbreviation_arg\"${NONE}"
+            fi
+            ;;
+        "used alias")
+            if zstyle -t ':you-should-use:*' you_used_alias_enabled; then
+                DEFAULT_MESSAGE_FORMAT="${BOLD} ${PURPLE}\"$command_arg\"${YELLOW} -> ${PURPLE}\"$abbreviation_arg\"${NONE}"
+            fi
+            ;;
+    esac
+    _write_ysu_buffer "$DEFAULT_MESSAGE_FORMAT\n"
+}
+
 # Prevent command from running if hardcore mode enabled
 function _check_ysu_hardcore() {
     if [[ "$YSU_HARDCORE" = 1 ]]; then
@@ -150,7 +185,6 @@ function _check_ysu_hardcore() {
         kill -s INT $$
     fi
 }
-
 
 function _check_git_aliases() {
     local typed="$1"
@@ -177,7 +211,6 @@ function _check_git_aliases() {
         fi
     fi
 }
-
 
 function _check_global_aliases() {
     local typed="$1"
@@ -300,44 +333,6 @@ function _check_aliases() {
         _check_ysu_hardcore
     fi
 }
-
-
-function ysu_message() {
-    local message_type="$1"
-    local command_arg="$2"
-    local abbreviation_arg="$3"
-    local DEFAULT_MESSAGE_FORMAT=""
-
-    # Escape arguments for safe output
-    command_arg="${command_arg//\%/%%}"
-    command_arg="${command_arg//\\/\\\\}"
-    abbreviation_arg="${abbreviation_arg//\%/%%}"
-    abbreviation_arg="${abbreviation_arg//\\/\\\\}"
-
-    # Determine message format based on message type and whether it's enabled
-    case "$message_type" in
-        "abbreviation")
-            if zstyle -t ':you-should-use:*' you_should_use_abbreviation_enabled; then
-                DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}Found existing abbreviation for ${PURPLE}\"$command_arg\"${YELLOW}. \
-You should use: ${PURPLE}\"$abbreviation_arg\"${NONE}"
-            fi
-            ;;
-        "alias")
-            if zstyle -t ':you-should-use:*' you_should_use_alias_enabled; then
-                DEFAULT_MESSAGE_FORMAT="${BOLD}${YELLOW}Found existing alias for ${PURPLE}\"$command_arg\"${YELLOW}. \
-You should use: ${PURPLE}\"$abbreviation_arg\"${NONE}"
-            fi
-            ;;
-        "used alias")
-            if zstyle -t ':you-should-use:*' you_used_alias_enabled; then
-                DEFAULT_MESSAGE_FORMAT="${BOLD} ${PURPLE}\"$command_arg\"${YELLOW} -> ${PURPLE}\"$abbreviation_arg\"${NONE}"
-            fi
-            ;;
-    esac
-    _write_ysu_buffer "$DEFAULT_MESSAGE_FORMAT\n"
-}
-
-
 
 function disable_you_should_use() {
     add-zsh-hook -D preexec _check_aliases

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -18,6 +18,12 @@ else
 fi
 
 function load_abbrs() {
+    if ! type abbr >/dev/null 2>&1; then
+        #Install zsh-abbr to use this
+        #https://zsh-abbr.olets.dev/
+        return
+    fi
+
     typeset -gA abbrs
     local line abbr_cmd abbr_expansion
 
@@ -34,6 +40,11 @@ function load_abbrs() {
 
 
 function load_abbrs_from_file() {
+    if ! type abbr >/dev/null 2>&1; then
+        #Install zsh-abbr to use this
+        #https://zsh-abbr.olets.dev/
+        return
+    fi
     # Fetch abbreviation list from file
     local abbr_file="$ABBR_USER_ABBREVIATIONS_FILE"
     declare -gA abbrs   # Ensure 'abbrs' is declared as a global associative array
@@ -49,6 +60,11 @@ function load_abbrs_from_file() {
 }
 
 function _check_abbrs() {
+    if ! type abbr >/dev/null 2>&1; then
+        #Install zsh-abbr to use this
+        #https://zsh-abbr.olets.dev/
+        return
+    fi
     local typed="$1"
     # Directly using the typed command to look up its abbreviation
     local abbr_match="${abbrs[$typed]}"
@@ -356,7 +372,9 @@ function disable_you_should_use() {
     add-zsh-hook -D preexec _check_global_aliases
     add-zsh-hook -D preexec _check_git_aliases
     add-zsh-hook -D precmd _flush_ysu_buffer
-    add-zsh-hook -D preexec _check_abbrs
+    if type abbr >/dev/null 2>&1; then
+        add-zsh-hook -D preexec _check_abbrs
+    fi
 }
 
 function enable_you_should_use() {
@@ -365,9 +383,14 @@ function enable_you_should_use() {
     add-zsh-hook preexec _check_global_aliases
     add-zsh-hook preexec _check_git_aliases
     add-zsh-hook precmd _flush_ysu_buffer
-    add-zsh-hook preexec _check_abbrs
+    if type abbr >/dev/null 2>&1; then
+        add-zsh-hook preexec _check_abbrs
+    fi
+    
 }
 
 autoload -Uz add-zsh-hook
 enable_you_should_use
-load_abbrs
+if type abbr >/dev/null 2>&1; then
+   load_abbrs
+fi

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -378,7 +378,6 @@ function enable_you_should_use() {
 }
 
 zstyle ':you-should-use:*' you_should_use_alias_enabled true
-zstyle ':you-should-use:*' you_used_alias_enabled false
 zstyle ':you-should-use:*' you_should_use_abbreviation_enabled false
 
 autoload -Uz add-zsh-hook
@@ -386,4 +385,3 @@ enable_you_should_use
 if zstyle -T ':you-should-use:*' you_should_use_abbreviation_enabled; then
     load_abbrs
 fi
-

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -18,6 +18,23 @@ else
 fi
 
 function load_abbrs() {
+    typeset -gA abbrs
+    local line abbr_cmd abbr_expansion
+
+    # Fetch abbreviation list directly using abbr list command
+    abbr list | while IFS="=" read -r abbr_cmd abbr_expansion; do
+        # Remove quotes around the command and expansion
+        abbr_cmd=${abbr_cmd//\"/}
+        abbr_expansion=${abbr_expansion//\"/}
+
+        # Store in associative array
+        abbrs[$abbr_cmd]=$abbr_expansion
+    done
+}
+
+
+function load_abbrs_from_file() {
+    # Fetch abbreviation list from file
     local abbr_file="$ABBR_USER_ABBREVIATIONS_FILE"
     declare -gA abbrs   # Ensure 'abbrs' is declared as a global associative array
     local line abbr_cmd abbr_expansion

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -220,8 +220,8 @@ function _check_aliases() {
     local found_aliases=()
     local best_match=""
     local best_match_value=""
-    local key
-    local value
+    local key=""
+    local value=""
 
     # sudo will use another user's profile and so aliases would not apply
     if [[ "$typed" = "sudo "* ]]; then


### PR DESCRIPTION
Added ability to show what alias you just used is aliased to (more like a "you used" opposite of "you should use" in case you forget you keep using aliases (#131)

The reason I think it's very important is because oftentimes you use an alias without remembering you did and then you wonder why things don't work, especially if you alias very common things like ls or rm.

Example, I recently aliased ls to eza, and found that ls -t works, but eza -t required a flag, and this broke a bunch of my scripts. Its more a reminder you used an alias.

I am happy to maintain the you-used part