### PR TITLE
Make some tests more lenient

### DIFF
--- a/tests/test_buffer.zunit
+++ b/tests/test_buffer.zunit
@@ -38,6 +38,8 @@
 }
 
 @test 'ysu - _write_ysu_buffer invalid' {
+    (( $+commands[tput] )) || skip "tput not found"
+
     YSU_MESSAGE_POSITION="invalid"
     export _YSU_BUFFER
 

--- a/tests/test_you_should_use.zunit
+++ b/tests/test_you_should_use.zunit
@@ -6,6 +6,9 @@
 }
 
 @test 'ysu version exported' {
+    (( $+commands[git] )) || skip "git not found"
+    [ -d ".git" ] || skip "not in git repo"
+
     git_version="$(git tag --list | sort | tail -1)"
     git tag --list
 

--- a/tests/test_you_should_use.zunit
+++ b/tests/test_you_should_use.zunit
@@ -34,6 +34,8 @@
 }
 
 @test 'ysu message correct output' {
+    (( $+commands[tput] )) || skip "tput not found"
+
     unset YSU_MESSAGE_FORMAT
     run ysu_message "alias" "ls -l" "ll"
 
@@ -46,6 +48,8 @@
 }
 
 @test 'ysu message correct output 2' {
+    (( $+commands[tput] )) || skip "tput not found"
+
     unset YSU_MESSAGE_FORMAT
     run ysu_message "foobar" "2>/dev/null" "NE"
 
@@ -58,6 +62,8 @@
 }
 
 @test 'escapes \ and % correctly' {
+    (( $+commands[tput] )) || skip "tput not found"
+
     unset YSU_MESSAGE_FORMAT
     run ysu_message "alias" "printf '%s\\n'" "pf"
 


### PR DESCRIPTION
* [tests: skip tests requiring tput if not present](https://github.com/MichaelAquilina/zsh-you-should-use/commit/ecb3642e417800c94ad69d6608af7e23bf23bc9f)
  * tput appears to be optional for this plugin, so the tests should not fail if we cannot find tput.
* [tests: skip tests requiring git or git repo](https://github.com/MichaelAquilina/zsh-you-should-use/commit/878c212ef6b1b49a8ffcc558a561ab5df5709233)
  * In some exotic packaging environments like Nixpkgs, we enforce heavy amounts of sandboxing; we do not include git by default in that sandbox.
  * Additionally, in said exotic packaging environments, we should not always assume we are in a Git repository. The Nixpkgs GitHub fetcher functions by downloading a tarball, not the whole Git directory, so the test fails.

This is part of my work to improve the Nixpkgs package for YSU by having unit tests be executed, so potential breakages are caught early.