### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Clone this repository using the following command:
 
     git clone https://github.com/MichaelAquilina/zsh-you-should-use.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/you-should-use
 
-``$ZSH_CUSTOM`` is oh-my-zsh’s customization directory (`docs <https://github.com/robbyrussell/oh-my-zsh/wiki/Customization/>`__).
+``$ZSH_CUSTOM`` is oh-my-zsh's customization directory (`docs <https://github.com/robbyrussell/oh-my-zsh/wiki/Customization/>`__).
 
 Then add ``you-should-use`` to the ``plugins`` array in your ``.zshrc``:
 


### PR DESCRIPTION
Use normal ASCII apostrophe (') instead of curly apostrophe (’)
```
This file contains ambiguous Unicode characters
This file contains Unicode characters that might be confused with other characters. If you think that this is intentional, you can safely ignore this warning. Use the Escape button to reveal them.
```