### PR TITLE
Aliases with stars `sudo` works

### DIFF
--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -209,11 +209,6 @@ function _check_aliases() {
     local key
     local value
 
-    # sudo will use another user's profile and so aliases would not apply
-    if [[ "$typed" = "sudo "* ]]; then
-        return
-    fi
-
     # Find alias matches
     for key in "${(@k)aliases}"; do
         value="${aliases[$key]}"


### PR DESCRIPTION
Even though the code doesn't look commands that starts with sudo this affects aliases that stars with sudo.

Let's say I have two aliases
```bash
alias agi='sudo apt install'
alias gst='git status'
```
(The first alias from ohmyzsh's ubuntu plugin, the second one is from git)

With my changes when I run `git status` it says
```zsh
❯ git status
Found existing alias for "git status". You should use: "gst"
On branch master
...
```

When I run `sudo git status` it doesn't say anything. Since I don't have a alias that points to `sudo git status`
```zsh
❯ sudo git status
On branch master
...
```

Also when I run `sudo apt install` it reminds me that I have an alias
```zsh
❯ sudo apt install
Found existing alias for "sudo apt install". You should use: "agi"
Summary:                        
  Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 0
```

Also when I run only `apt install` it doesn't say that I have an alias (because I don't)

```zsh
❯ apt install                     
Error: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
Error: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```

So I think with this remove the check of the sudo from `_check_aliases` function it does what it should do and also passes all the `zunit` tests.