### PR TITLE
fix: don't downgrade an already-best compound alias in BESTMATCH mode

### DIFF
--- a/tests/test_aliases.zunit
+++ b/tests/test_aliases.zunit
@@ -84,6 +84,43 @@
     assert $state equals 0
 }
 
+@test 'aliases bestmatch - already-best compound alias is not downgraded to a shorter one' {
+    export YSU_MODE="BESTMATCH"
+    alias g='git'
+    alias gp='git push'
+    alias gpf='git push --force-with-lease'
+    alias gf='git fetch'
+    alias gfa='git fetch --all --prune --jobs=10'
+
+    # Typing an alias that is already the most specific match must not suggest
+    # a shorter, less specific alias (regression for the tie-break that compared
+    # a candidate's value length against the best match's *name* length).
+    run _check_aliases 'gpf' 'git push --force-with-lease'
+    assert "$output" is_empty
+    assert $state equals 0
+
+    run _check_aliases 'gfa' 'git fetch --all --prune --jobs=10'
+    assert "$output" is_empty
+    assert $state equals 0
+}
+
+@test 'aliases bestmatch - full command suggests the most specific compound alias' {
+    export YSU_MODE="BESTMATCH"
+    alias g='git'
+    alias gp='git push'
+    alias gpf='git push --force-with-lease'
+    alias gf='git fetch'
+    alias gfa='git fetch --all --prune --jobs=10'
+
+    run _check_aliases 'git push --force-with-lease'
+    assert "$output" contains 'Found existing alias for "git push --force-with-lease". You should use: "gpf"'
+    assert $state equals 0
+
+    run _check_aliases 'git fetch --all --prune --jobs=10'
+    assert "$output" contains 'Found existing alias for "git fetch --all --prune --jobs=10". You should use: "gfa"'
+    assert $state equals 0
+}
+
 @test 'aliases ignore if sudo' {
     unset YSU_MODE
     alias gs="git status"

--- a/you-should-use.plugin.zsh
+++ b/you-should-use.plugin.zsh
@@ -264,7 +264,7 @@ function _check_aliases() {
                 best_match="$key"
                 best_match_value="$value"
             # on equal length, choose the shortest alias
-            elif [[ "${#value}" -eq "${#best_match}" && ${#key} -lt "${#best_match}" ]]; then
+            elif [[ "${#value}" -eq "${#best_match_value}" && ${#key} -lt "${#best_match}" ]]; then
                 best_match="$key"
                 best_match_value="$value"
             fi


### PR DESCRIPTION
## Problem

In `BESTMATCH` mode, typing an alias that is already the most specific match can suggest a shorter, less specific alias:

```
g='git'
gp='git push'
gpf='git push --force-with-lease'
```

Typing `gpf` wrongly prints `You should use: "gp"`.
Expected: nothing.

## Cause

The best-match tie-break compared the candidate's **value** length against the best match's **name** length (`${#best_match}`) instead of its value length (`${#best_match_value}`), so a short alias could spuriously clobber the correct best match.

(Leftover from commit ca04883, which converted the `if` to `best_match_value` but missed the same swap in the `elif`.)

## Fix

```diff
 if [[ "${#value}" -gt "${#best_match_value}" ]]; then
   ...
-elif [[ "${#value}" -eq "${#best_match}" && ${#key} -lt "${#best_match}" ]]; then
+elif [[ "${#value}" -eq "${#best_match_value}" && ${#key} -lt "${#best_match}" ]]; then
   ...
 fi
```